### PR TITLE
fix: blur() ignores the amount argument

### DIFF
--- a/src/Transformations/Blur.php
+++ b/src/Transformations/Blur.php
@@ -20,7 +20,7 @@ class Blur implements TransformationInterface
 
         return [
             self::STRENGTH => $strength,
-            self::AMOUNT => $strength,
+            self::AMOUNT => $amount,
         ];
     }
 

--- a/tests/TransformationTest.php
+++ b/tests/TransformationTest.php
@@ -198,3 +198,7 @@ it('can strip meta information', function () {
     $url = (string) $transformation->stripMeta('sensitive');
     expect($url)->toBe('https://ucarecdn.com/12a3456b-c789-1234-1de2-3cfa83096e25/-/strip_meta/sensitive/');
 });
+
+it('uses the correct amount argument in blur', function () {
+    expect((string) uploadcare('12a3456b-c789-1234-1de2-3cfa83096e25')->blur(10, 5))->toContain('-/blur/10/5/');
+});


### PR DESCRIPTION
## Bug

In `src/Transformations/Blur.php`, the `transform()` method stored `$strength` in both the `strength` and `amount` keys of the returned array:

```php
return [
    self::STRENGTH => $strength,
    self::AMOUNT => $strength,  // bug: should be $amount
];
```

This means calling `blur(10, 5)` would produce `-/blur/10/10/` instead of `-/blur/10/5/` — the second argument was silently ignored.

## Fix

Changed `self::AMOUNT => $strength` to `self::AMOUNT => $amount`.

## Why it matters

This was surfaced during a React-port of the package. The React implementation passed distinct strength and amount values and received unexpected results, revealing the PHP-side bug.

## Test added

```php
it('uses the correct amount argument in blur', function () {
    expect((string) uploadcare('12a3456b-c789-1234-1de2-3cfa83096e25')->blur(10, 5))->toContain('-/blur/10/5/');
});
```