### PR TITLE
fix: autoRotate() ignores its boolean argument

### DIFF
--- a/src/Transformations.php
+++ b/src/Transformations.php
@@ -338,7 +338,7 @@ class Transformations
      */
     public function autoRotate(bool $rotate): self
     {
-        $this->transformations['auto_rotate'] = AutoRotate::transform();
+        $this->transformations['auto_rotate'] = AutoRotate::transform($rotate);
 
         return $this;
     }

--- a/src/Transformations/AutoRotate.php
+++ b/src/Transformations/AutoRotate.php
@@ -10,7 +10,7 @@ class AutoRotate implements TransformationInterface
 
     public static function transform(...$args): array
     {
-        $autoRotate = $args['auto_rotate'] ?? false;
+        $autoRotate = $args[0] ?? false;
 
         return [
             self::AUTO_ROTATE => $autoRotate,

--- a/tests/TransformationTest.php
+++ b/tests/TransformationTest.php
@@ -198,3 +198,10 @@ it('can strip meta information', function () {
     $url = (string) $transformation->stripMeta('sensitive');
     expect($url)->toBe('https://ucarecdn.com/12a3456b-c789-1234-1de2-3cfa83096e25/-/strip_meta/sensitive/');
 });
+
+it('honors the boolean argument in autoRotate', function () {
+    $uuid = '12a3456b-c789-1234-1de2-3cfa83096e25';
+
+    expect((string) uploadcare($uuid)->autoRotate(true))->toContain('-/autorotate/yes/');
+    expect((string) uploadcare($uuid)->autoRotate(false))->toContain('-/autorotate/no/');
+});


### PR DESCRIPTION
## Bug

Two defects combined to make `autoRotate()` always emit `-/autorotate/no/` regardless of the argument passed:

1. **`src/Transformations.php`** — `autoRotate(bool $rotate)` called `AutoRotate::transform()` with **no arguments**, discarding `$rotate` entirely.

2. **`src/Transformations/AutoRotate.php`** — `transform()` read `$args['auto_rotate'] ?? false`, a named-key lookup that can never be satisfied when the method receives positional variadic args, so it always resolved to `false`.

## Fix

- In `src/Transformations.php`: pass the bool — `AutoRotate::transform($rotate)`.
- In `src/Transformations/AutoRotate.php`: read the positional arg — `$autoRotate = $args[0] ?? false;`.

## Test added

```php
it('honors the boolean argument in autoRotate', function () {
    $uuid = '12a3456b-c789-1234-1de2-3cfa83096e25';

    expect((string) uploadcare($uuid)->autoRotate(true))->toContain('-/autorotate/yes/');
    expect((string) uploadcare($uuid)->autoRotate(false))->toContain('-/autorotate/no/');
});
```