### PR TITLE
fix: iccProfileSizeThreshold() without convertToSRGB() crashes

### DIFF
--- a/src/Transformations/TransformationsFinder.php
+++ b/src/Transformations/TransformationsFinder.php
@@ -98,6 +98,10 @@ class TransformationsFinder
             // We need to check if ICCProfileSizeThreshold is used because it is a special case.
             // This is because the URL transformation is a part of the ConvertToSRGB transformation.
             if ($transformation === self::ICC_PROFILE_SIZE_THRESHOLD) {
+                if (! isset($transformations[self::CONVERT_TO_SRGB])) {
+                    throw new \InvalidArgumentException('iccProfileSizeThreshold requires convertToSRGB');
+                }
+
                 $classes[self::CONVERT_TO_SRGB] = [
                     'class' => new ConvertToSRGB(),
                     'values' => [

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -83,3 +83,9 @@ it('can validate resize mode enum', function () {
 
     $transformation->resize(width: 500, height: 500, stretch: false, mode: 'invalid_resize_mode');
 })->throws('Invalid resize mode');
+
+it('throws when iccProfileSizeThreshold is used without convertToSRGB', function () {
+    $uuid = '12a3456b-c789-1234-1de2-3cfa83096e25';
+
+    (string) uploadcare($uuid)->iccProfileSizeThreshold(10);
+})->throws(\InvalidArgumentException::class, 'iccProfileSizeThreshold requires convertToSRGB');


### PR DESCRIPTION
## Bug

In `src/Transformations/TransformationsFinder.php`, the `for()` method handles `icc_profile_size_threshold` as a special case by merging it into the `convert_to_srgb` transformation:

```php
'profile' => $transformations[self::CONVERT_TO_SRGB]['profile'],
```

If `iccProfileSizeThreshold()` is called without first calling `convertToSRGB()`, the key `convert_to_srgb` is absent from `$transformations`, resulting in a PHP undefined-index error (or TypeError in strict mode) — an unhelpful crash with no actionable message.

## Fix

Added a guard before accessing the key that throws a clear `InvalidArgumentException`:

```php
if (! isset($transformations[self::CONVERT_TO_SRGB])) {
    throw new \InvalidArgumentException('iccProfileSizeThreshold requires convertToSRGB');
}
```

The existing happy-path test (`convertToSRGB('fast')->iccProfileSizeThreshold(10)`) continues to pass.

## Test added

```php
it('throws when iccProfileSizeThreshold is used without convertToSRGB', function () {
    $uuid = '12a3456b-c789-1234-1de2-3cfa83096e25';

    (string) uploadcare($uuid)->iccProfileSizeThreshold(10);
})->throws(\InvalidArgumentException::class, 'iccProfileSizeThreshold requires convertToSRGB');
```