### PR TITLE
fix: filter() without an amount produces a double slash

### DIFF
--- a/src/Transformations/Filter.php
+++ b/src/Transformations/Filter.php
@@ -48,7 +48,11 @@ class Filter implements TransformationInterface
     public static function generateUrl(string $url, array $values): string
     {
         // -/filter/:name/:amount/
-        $url .= '-/filter/' . $values['name'] . '/' . $values['amount'] . '/';
+        if ($values['amount'] === null) {
+            $url .= '-/filter/' . $values['name'] . '/';
+        } else {
+            $url .= '-/filter/' . $values['name'] . '/' . $values['amount'] . '/';
+        }
 
         return $url;
     }

--- a/tests/TransformationTest.php
+++ b/tests/TransformationTest.php
@@ -198,3 +198,14 @@ it('can strip meta information', function () {
     $url = (string) $transformation->stripMeta('sensitive');
     expect($url)->toBe('https://ucarecdn.com/12a3456b-c789-1234-1de2-3cfa83096e25/-/strip_meta/sensitive/');
 });
+
+it('omits the amount segment in filter when no amount is given', function () {
+    $uuid = '12a3456b-c789-1234-1de2-3cfa83096e25';
+
+    $url = (string) uploadcare($uuid)->filter('adaris');
+    expect($url)->toContain('-/filter/adaris/');
+    expect($url)->not->toContain('adaris//');
+
+    $url = (string) uploadcare($uuid)->filter('adaris', 50);
+    expect($url)->toContain('-/filter/adaris/50/');
+});


### PR DESCRIPTION
## Bug

In `src/Transformations/Filter.php`, `generateUrl()` unconditionally appended the amount:

```php
$url .= '-/filter/' . $values['name'] . '/' . $values['amount'] . '/';
```

When `filter('adaris')` is called without an amount, `$values['amount']` is `null`, which PHP casts to an empty string, yielding `-/filter/adaris//` — a double slash that produces an invalid Uploadcare URL.

## Fix

Conditionally omit the amount segment when it is `null`:

```php
if ($values['amount'] === null) {
    $url .= '-/filter/' . $values['name'] . '/';
} else {
    $url .= '-/filter/' . $values['name'] . '/' . $values['amount'] . '/';
}
```

The `transform()` validation is unchanged — null amount is permitted.

## Test added

```php
it('omits the amount segment in filter when no amount is given', function () {
    $uuid = '12a3456b-c789-1234-1de2-3cfa83096e25';

    $url = (string) uploadcare($uuid)->filter('adaris');
    expect($url)->toContain('-/filter/adaris/');
    expect($url)->not->toContain('adaris//');

    $url = (string) uploadcare($uuid)->filter('adaris', 50);
    expect($url)->toContain('-/filter/adaris/50/');
});
```

Note: `filter` triggers automatic `-/preview/` insertion (the `getUrl()` logic), so assertions use `toContain` rather than exact `toBe` matching.