### PR TITLE
CI: drop EOL PHP 8.1/8.2, require PHP 8.3+

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Cache composer dependencies
         uses: actions/cache@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1, 8.2, 8.3]
+        php: [8.3, 8.4]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^8.1|^8.2|^8.3"
+        "php": "^8.3|^8.4"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.85",


### PR DESCRIPTION
## Problem

CI is red on `main` and on every open PR. The jobs fail in ~10s at the **dependency install** step, before any test runs:

```
Your requirements could not be resolved to an installable set of packages.
  - brianium/paratest ... require php ~8.3.0 || ~8.4.0 -> your php version (8.1.34) does not satisfy that requirement.
  - pestphp/pest[v2.36.1, ..., 2.x-dev] require php ^8.2.0 -> your php version (8.1.34) does not satisfy that requirement.
```

The test toolchain (`pestphp/pest` ≥2.36.1 and its dependency `brianium/paratest` ≥7.4) has dropped PHP 8.1/8.2, so `composer` can no longer resolve dev dependencies on the 8.1 (and several 8.2) matrix legs. PHP 8.1 and 8.2 are also end-of-life.

## Fix

- `composer.json`: `"php": "^8.1|^8.2|^8.3"` → `"^8.3|^8.4"`
- `.github/workflows/run-tests.yml`: matrix `php: [8.1, 8.2, 8.3]` → `[8.3, 8.4]`
- `.github/workflows/phpstan.yml`: `php-version: "8.1"` → `"8.3"`

Locally: `composer test` → all green, `phpstan analyse` → no errors.

## Note

This unblocks the four bug-fix PRs (#55–#58). Merge this first; their checks then pass against the updated base.